### PR TITLE
fix: bump scan runner to xl

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   scan:
-    runs-on: k8s-general
+    runs-on: k8s-general-xl
     strategy:
       matrix:
         branch: ["main"]


### PR DESCRIPTION
### What

- Bump scan runner to `xl`

### Why

- Failure on [last run](https://github.com/dailypay/dailypay-typescript-sdk/actions/runs/17297818275), google indicating a possible OOM failure

### Related Links

* [JIRA](https://dailypay.atlassian.net/browse/INFRA-6362)
