### PR TITLE
fix: make scan workflow reusable, add license

### DIFF
--- a/.github/workflows/reusable-scan.yaml
+++ b/.github/workflows/reusable-scan.yaml
@@ -2,14 +2,22 @@ name: "Scan"
 
 on:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        description: Branch name to target scan on
+        required: true
   workflow_call:
+    inputs:
+      branch_name:
+        description: Branch name to target scan on
+        required: true
+        default: main
 
 inputs:
   branch_name:
     description: Branch name to target scan on
     required: true
     default: main
-
 
 permissions:
   pull-requests: write

--- a/.github/workflows/reusable-scan.yaml
+++ b/.github/workflows/reusable-scan.yaml
@@ -6,18 +6,13 @@ on:
       branch_name:
         description: Branch name to target scan on
         required: true
+        type: string
+        default: main
   workflow_call:
     inputs:
       branch_name:
         description: Branch name to target scan on
         required: true
-        default: main
-
-inputs:
-  branch_name:
-    description: Branch name to target scan on
-    required: true
-    default: main
 
 permissions:
   pull-requests: write

--- a/.github/workflows/reusable-scan.yaml
+++ b/.github/workflows/reusable-scan.yaml
@@ -1,0 +1,42 @@
+name: "Scan"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+inputs:
+  branch_name:
+    description: Branch name to target scan on
+    required: true
+    default: main
+
+
+permissions:
+  pull-requests: write
+  contents: write
+  security-events: write
+  id-token: write
+
+env:
+  GOPRIVATE: github.com/dailypay
+
+jobs:
+  scan:
+    runs-on: k8s-general
+    strategy:
+      matrix:
+        branch: ["${{ inputs.branch_name }}"]
+    steps:
+      - name: configure git
+        uses: dailypay/actions-commons/git-configure@v0
+
+      - name: scan
+        uses: jfrog/frogbot@v2
+        env:
+          JF_URL: https://artifactory.dailypay.com
+          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JF_GIT_BASE_BRANCH: ${{ matrix.branch }}
+        with:
+          oidc-provider-name: github
+          oidc-audience: dailypay-github
+          version: ${{ vars.FROGBOT_VERSION }}

--- a/.github/workflows/reusable-scan.yaml
+++ b/.github/workflows/reusable-scan.yaml
@@ -5,14 +5,15 @@ on:
     inputs:
       branch_name:
         description: Branch name to target scan on
+        default: main
         required: true
         type: string
-        default: main
   workflow_call:
     inputs:
       branch_name:
         description: Branch name to target scan on
         required: true
+        type: string
 
 permissions:
   pull-requests: write

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -3,7 +3,7 @@ name: "Scan"
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull-requests:
+  pull-request:
     types: [published]
     branches:
       - main

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -3,7 +3,7 @@ name: "Scan"
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull-request:
+  pull_request:
     types: [published]
     branches:
       - main

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -3,7 +3,15 @@ name: "Scan"
 on:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
+  pull-requests:
+    types: [published]
+
+inputs:
+  branch_name:
+    description: Branch name to target scan on
+    required: true
+    default: main
+
 
 permissions:
   pull-requests: write
@@ -11,26 +19,9 @@ permissions:
   security-events: write
   id-token: write
 
-env:
-  GOPRIVATE: github.com/dailypay
-
 jobs:
   scan:
-    runs-on: k8s-general
-    strategy:
-      matrix:
-        branch: ["main"]
-    steps:
-      - name: configure git
-        uses: dailypay/actions-commons/git-configure@v0
-
-      - name: scan
-        uses: jfrog/frogbot@v2
-        env:
-          JF_URL: https://artifactory.dailypay.com
-          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JF_GIT_BASE_BRANCH: ${{ matrix.branch }}
-        with:
-          oidc-provider-name: github
-          oidc-audience: dailypay-github
-          version: ${{ vars.FROGBOT_VERSION }}
+    uses: ./.github/workflows/reusable-scan.yaml
+    secrets: inherit
+    with:
+      branch_name: ${{ inputs.branch_name }}

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -5,13 +5,8 @@ on:
     - cron: "0 0 * * *"
   pull-requests:
     types: [published]
-
-inputs:
-  branch_name:
-    description: Branch name to target scan on
-    required: true
-    default: main
-
+    branches:
+      - main
 
 permissions:
   pull-requests: write
@@ -24,4 +19,4 @@ jobs:
     uses: ./.github/workflows/reusable-scan.yaml
     secrets: inherit
     with:
-      branch_name: ${{ inputs.branch_name }}
+      branch_name: ${{ github.event_name == 'pull-request' && github.ref_name || 'main' }}

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
-    types: [published]
     branches:
       - main
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) DailyPay 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### What

- Make scan workflow reusable
- Scan on pull-requests
- Add MIT license (pulled from GitHub templates [here](https://github.com/licenses/license-templates/blob/master/templates/mit.txt))

### Why

- Security

### Related Links

* [JIRA](https://dailypay.atlassian.net/browse/INFRA-6362)
