### PR TITLE
fix(speakeasy): [DBI-1684] stop daily SDK regeneration from stacking duplicate PRs

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -21,7 +21,6 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       mode: pr
-      target: typescript
       force: ${{ github.event.inputs.force }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What Changed

Removed the `target:` input from the `sdk-generation` workflow's call to `speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15`.

### Why

The Speakeasy action's `FindExistingPR` builds the PR-title prefix it searches for by appending the `target:` value in uppercase (e.g. `TYPESCRIPT`) when that string isn't already in the workflow name. The CLI-generated PR title omits it (`chore: 🐝 Update SDK - Generate Typescript SDK 0.14.3`), so the search prefix never matched, the action logged `Existing PR not found`, and it opened a new `speakeasy-sdk-regen-<timestamp>` branch and PR on every daily run instead of reusing the open one.

With `target:` removed, the search prefix (`chore: 🐝 Update SDK - Generate <Name> SDK`) is again a true prefix of the actual title, so the action finds and updates the existing PR. This is safe because each repo's `.speakeasy/workflow.yaml` defines exactly one target, so the executor generates the same SDK whether or not `target:` is passed.

### How to Test

Covered by the scheduled workflow: trigger it twice (or run `workflow_dispatch`) without merging in between and confirm one open regeneration PR is updated rather than a second one opened.

### Jira

[DBI-1684](https://dailypay.atlassian.net/browse/DBI-1684)


[DBI-1684]: https://dailypay.atlassian.net/browse/DBI-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ